### PR TITLE
Remove text-rendering property

### DIFF
--- a/build/include/bootstrap/css/bootstrap.css
+++ b/build/include/bootstrap/css/bootstrap.css
@@ -621,7 +621,6 @@ h6 {
   font-weight: bold;
   line-height: 20px;
   color: inherit;
-  text-rendering: optimizelegibility;
 }
 h1 small,
 h2 small,


### PR DESCRIPTION
text-rendering is causing some pretty bad issue on Windows Chrome. Some special UTF-8 characters won't be shown and some text section can change font-face.
