### PR TITLE
Fix NavBar color in IE

### DIFF
--- a/build/include/style.css
+++ b/build/include/style.css
@@ -161,7 +161,8 @@ article p a:hover {
  */
 header nav .navbar-inner {
 	min-height: inherit;
-	background: NAVBAR_BG !important; 
+	background: NAVBAR_BG !important;
+	filter: none;
 }
 
 header nav ul {


### PR DESCRIPTION
Fix #1 mentioned issue: navbar menu crumble in IE.

Related post with this IE issue:

[Twitter Bootstrap - nav bar issues in internet explorer](http://stackoverflow.com/questions/9780464/twitter-bootstrap-nav-bar-issues-in-internet-explorer)

[Twitter BootStrap NavBar Color in IE8/9](http://www.anujgakhar.com/2012/09/05/twitter-bootstrap-navbar-color-in-ie89/)
